### PR TITLE
Harden runtime lifecycle, expand scanner workload coverage, and secure AI auth defaults

### DIFF
--- a/ai-module/server.py
+++ b/ai-module/server.py
@@ -343,14 +343,18 @@ detector = AnomalyDetector()
 
 # ============== AUTHENTICATION SETUP ==============
 TRAINING_API_TOKEN = os.environ.get('TRAINING_API_TOKEN')
+ALLOW_UNAUTHENTICATED_API = os.environ.get('ALLOW_UNAUTHENTICATED_API', 'false').lower() in ('true', '1', 'yes')
 
 def require_train_token(f):
     """Decorator to verify training API token (optional for demo mode)."""
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        # Demo mode: if no token is configured, skip auth checks.
-        if not TRAINING_API_TOKEN:
+        # Explicit demo mode only.
+        if ALLOW_UNAUTHENTICATED_API:
             return f(*args, **kwargs)
+        if not TRAINING_API_TOKEN:
+            logger.error("TRAINING_API_TOKEN is required when ALLOW_UNAUTHENTICATED_API is false")
+            return jsonify({'error': 'Server misconfiguration: auth token required'}), 503
 
         auth_header = request.headers.get('Authorization', '')
         

--- a/docs/REPOSITORY-STRUCTURE.md
+++ b/docs/REPOSITORY-STRUCTURE.md
@@ -137,7 +137,8 @@ kubesentinel/
 - **`ai-module/`** - Flask-based ML service
   - Runs on port 5000
   - Exposes `/predict` (anomaly detection), `/train` (model update)
-  - Protected endpoints via Bearer token authentication
+  - Protected endpoints via Bearer token authentication (`TRAINING_API_TOKEN` required by default)
+  - Optional local-demo bypass via `ALLOW_UNAUTHENTICATED_API=true`
   - Includes Prometheus `/metrics` endpoint
 
 - **`cspm/`** - Static manifest scanning

--- a/internal/runtime/monitor.go
+++ b/internal/runtime/monitor.go
@@ -179,10 +179,20 @@ func (m *Monitor) Start() error {
 
 func (m *Monitor) consumeFromSocket() {
 	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		default:
+		}
+
 		conn, err := net.Dial("unix", m.config.FalcoSocket)
 		if err != nil {
 			fmt.Printf("Failed to connect to Falco socket %s: %v\n", m.config.FalcoSocket, err)
-			time.Sleep(5 * time.Second)
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
@@ -206,6 +216,9 @@ func (m *Monitor) consumeFromSocket() {
 			}
 
 			select {
+			case <-m.ctx.Done():
+				conn.Close()
+				return
 			case m.eventChan <- event:
 			default:
 				fmt.Println("Warning: event channel full, dropping event")
@@ -369,6 +382,7 @@ func (m *Monitor) Stop() {
 		return
 	}
 	m.cancel()
+	m.processor.Stop()
 	m.closeOnce.Do(func() { close(m.eventChan) })
 }
 

--- a/internal/runtime/processor.go
+++ b/internal/runtime/processor.go
@@ -25,6 +25,7 @@ type EventProcessor struct {
 	wg               sync.WaitGroup
 	warmupMinutes    int
 	warmupComplete   atomic.Bool
+	cancelLoops      context.CancelFunc
 }
 
 // ProcessorMetrics tracks processing statistics
@@ -139,27 +140,50 @@ func NewEventProcessor(workers int, aiClient *ai.Client, warmupMinutes int, vaul
 		ep.warmupComplete.Store(true) // no warm-up → immediately active
 	}
 
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	ep.cancelLoops = loopCancel
+
 	// === AUTO TRAINING TICKER (runs after warm-up) ===
+	ep.wg.Add(1)
 	go func() {
+		defer ep.wg.Done()
 		ticker := time.NewTicker(2 * time.Minute)
 		defer ticker.Stop()
-		for range ticker.C {
-			if ep.warmupComplete.Load() {
-				ep.TrainBaseline(context.Background())
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				if ep.warmupComplete.Load() {
+					ep.TrainBaseline(loopCtx)
+				}
 			}
 		}
 	}()
 
 	// Sliding window (you already had this)
+	ep.wg.Add(1)
 	go func() {
+		defer ep.wg.Done()
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
-		for range ticker.C {
-			ep.FeatureExtractor.resetWindow()
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				ep.FeatureExtractor.resetWindow()
+			}
 		}
 	}()
 
 	return ep
+}
+
+func (ep *EventProcessor) Stop() {
+	if ep.cancelLoops != nil {
+		ep.cancelLoops()
+	}
 }
 
 // Start begins processing events with worker goroutines
@@ -179,6 +203,7 @@ func (ep *EventProcessor) Start(ctx context.Context, eventChan <-chan SecurityEv
 		fmt.Println("All event processors stopped")
 	}()
 }
+
 func (ep *EventProcessor) Wait() {
 	ep.wg.Wait()
 }

--- a/internal/runtime/processor_shutdown_test.go
+++ b/internal/runtime/processor_shutdown_test.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"kubesentinel/internal/ai"
+)
+
+func TestEventProcessorStopStopsBackgroundLoops(t *testing.T) {
+	client := ai.NewClient("http://127.0.0.1:65535", 0.5)
+	ep := NewEventProcessor(0, client, 0)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ep.Stop()
+		ep.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("event processor stop did not return in time")
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -56,12 +56,14 @@ func NewScanner(config *ScanConfig) (*Scanner, error) {
 // supportedWorkloadKinds checks if a resource kind has container specs
 func (s *Scanner) supportedWorkloadKinds(kind string) bool {
 	supported := map[string]bool{
-		"Pod":         true,
-		"Deployment":  true,
-		"DaemonSet":   true,
-		"StatefulSet": true,
-		"Job":         true,
-		"CronJob":     true,
+		"Pod":                   true,
+		"Deployment":            true,
+		"DaemonSet":             true,
+		"StatefulSet":           true,
+		"Job":                   true,
+		"CronJob":               true,
+		"ReplicaSet":            true,
+		"ReplicationController": true,
 	}
 	return supported[kind]
 }
@@ -388,7 +390,11 @@ func (s *Scanner) getContainers(resource K8sResource) []map[string]interface{} {
 	containers := []map[string]interface{}{}
 
 	appendContainers := func(spec map[string]interface{}) {
-		if containersList, ok := spec["containers"].([]interface{}); ok {
+		for _, key := range []string{"containers", "initContainers", "ephemeralContainers"} {
+			containersList, ok := spec[key].([]interface{})
+			if !ok {
+				continue
+			}
 			for _, c := range containersList {
 				if container, ok := c.(map[string]interface{}); ok {
 					containers = append(containers, container)
@@ -412,7 +418,7 @@ func (s *Scanner) getContainers(resource K8sResource) []map[string]interface{} {
 	switch resource.Kind {
 	case "Pod":
 		appendContainers(resource.Spec)
-	case "Deployment", "DaemonSet", "StatefulSet", "Job":
+	case "Deployment", "DaemonSet", "StatefulSet", "Job", "ReplicaSet", "ReplicationController":
 		if spec := getNestedSpec(resource.Spec, "template", "spec"); spec != nil {
 			appendContainers(spec)
 		}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -106,6 +106,25 @@ func TestGetContainersSupportsCommonWorkloads(t *testing.T) {
 			},
 			wantContainers: 1,
 		},
+		{
+			name: "replicaset with init container",
+			resource: K8sResource{
+				Kind: "ReplicaSet",
+				Spec: map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{"name": "app"},
+							},
+							"initContainers": []interface{}{
+								map[string]interface{}{"name": "init"},
+							},
+						},
+					},
+				},
+			},
+			wantContainers: 2,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Motivation

- Ensure deterministic shutdown of runtime processing loops to prevent goroutine leaks and improve reliability.  
- Fix scanner blind spots that miss real-world Kubernetes workload kinds and non-primary container lists.  
- Move the AI/ML service to secure-by-default authentication to avoid silently exposing sensitive endpoints in production.

### Description

- Add cancellable loop context and `Stop()` to `EventProcessor`, run auto-train and sliding-window ticker goroutines under its `WaitGroup`, and expose `Stop()` to cancel them.  
- Wire `Monitor.Stop()` to call `processor.Stop()` and update Falco socket ingestion to honor `m.ctx.Done()` during dial, backoff, and enqueue to allow responsive shutdown.  
- Expand scanner `supportedWorkloadKinds` to include `ReplicaSet` and `ReplicationController`, and enhance `getContainers` to include `initContainers` and `ephemeralContainers`.  
- Harden the Python AI service auth by requiring `TRAINING_API_TOKEN` by default and adding an explicit opt-in `ALLOW_UNAUTHENTICATED_API=true` for local/demo use, and update docs to reflect this default.

### Testing

- Added `internal/runtime/processor_shutdown_test.go` which verifies background loops stop promptly and passed in targeted test runs.  
- Extended `pkg/scanner/scanner_test.go` with a ReplicaSet + initContainer case and ran `go test ./pkg/scanner` which passed.  
- Ran targeted runtime tests via `go test ./internal/runtime -run 'TestEventProcessorStopStopsBackgroundLoops|TestMonitor|TestFeature|TestProcessor'` which passed.  
- A full `go test ./internal/runtime` run fails in this environment due to an integration test (`TestAIIntegration`) that requires a live AI service at `localhost:5000`; this is an external dependency rather than a regression introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14510a2f4832d898288d1e814cb20)